### PR TITLE
Storage updates in Android 11 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-save-image-gallery",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Cordova plugin to save base64 data as a png/jpg image into the device and applying compression if needed",
   "license": "MIT",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://www.phonegap.com/ns/plugins/1.0" id="cordova-save-image-gallery" version="0.0.26">
+<plugin xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://www.phonegap.com/ns/plugins/1.0" id="cordova-save-image-gallery" version="0.0.27">
 
   <engines>
     <engine name="cordova-ios" version=">=3.8.0" />

--- a/src/android/SaveImageGallery.java
+++ b/src/android/SaveImageGallery.java
@@ -67,7 +67,7 @@ public class SaveImageGallery extends CordovaPlugin {
             } else {
                 Log.d("SaveImageGallery", "Requesting permissions for WRITE_EXTERNAL_STORAGE");
                 PermissionHelper.requestPermission(this, WRITE_PERM_REQUEST_CODE, WRITE_EXTERNAL_STORAGE);
-            } 
+            }
         }
 
         return true;
@@ -161,29 +161,23 @@ public class SaveImageGallery extends CordovaPlugin {
         File retVal = null;
 
         try {
-            String deviceVersion = Build.VERSION.RELEASE;
             Calendar c = Calendar.getInstance();
             String date = EMPTY_STR + c.get(Calendar.YEAR) + c.get(Calendar.MONTH) + c.get(Calendar.DAY_OF_MONTH)
                     + c.get(Calendar.HOUR_OF_DAY) + c.get(Calendar.MINUTE) + c.get(Calendar.SECOND);
 
-            int check = deviceVersion.compareTo("2.3.3");
-
             File folder;
 
-            /*
-             * File path = Environment.getExternalStoragePublicDirectory(
-             * Environment.DIRECTORY_PICTURES ); //this throws error in Android
-             * 2.2
-             */
-            if (check >= 1) {
+            if (Build.VERSION.SDK_INT >= 30) {
+                // @see https://developer.android.com/about/versions/11/privacy/storage
+                folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD_MR1) {
                 folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-
-                if (!folder.exists()) {
-                    folder.mkdirs();
-                }
-
             } else {
                 folder = Environment.getExternalStorageDirectory();
+            }
+
+            if (!folder.exists()) {
+                folder.mkdirs();
             }
 
             // building the filename
@@ -243,7 +237,7 @@ public class SaveImageGallery extends CordovaPlugin {
 				return;
 			}
 		}
-		
+
 		switch (requestCode) {
 		case WRITE_PERM_REQUEST_CODE:
 			Log.d("SaveImageGallery", "User granted the permission for WRITE_EXTERNAL_STORAGE");


### PR DESCRIPTION
Hi. Thank you for your library. I have been using it for a long time.  But recently I have noticed error when trying to save file on Android 11.

https://developer.android.com/about/versions/11/privacy/storage
```
03-02 22:41:45.727  6512 22161 E MediaProvider: insertFileIfNecessary failed
03-02 22:41:45.727  6512 22161 E MediaProvider: java.lang.IllegalArgumentException: Primary directory null not allowed for content://media/external_primary/file; allowed directories are [Download, Documents]
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.ensureFileColumns(MediaProvider.java:2996)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.ensureUniqueFileColumns(MediaProvider.java:2661)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.insertFile(MediaProvider.java:3357)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.insertInternal(MediaProvider.java:3920)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.insert(MediaProvider.java:3625)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.insertFileForFuse(MediaProvider.java:7347)
03-02 22:41:45.727  6512 22161 E MediaProvider: 	at com.android.providers.media.MediaProvider.insertFileIfNecessaryForFuse(MediaProvider.java:7441)
03-02 22:41:45.728 23172 23721 E SaveImageToGallery: An exception occured while saving image: java.io.FileNotFoundException: /storage/emulated/0/tes_image_202222224145.jpeg: open failed: EPERM (Operation not permitted)
03-02 22:41:45.729 23172 23721 E PluginManager: Uncaught exception from plugin
03-02 22:41:45.729 23172 23721 E PluginManager: java.lang.NullPointerException: file
03-02 22:41:45.729 23172 23721 E PluginManager: 	at android.net.Uri.fromFile(Uri.java:473)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at com.agomezmoron.saveImageGallery.SaveImageGallery.scanPhoto(SaveImageGallery.java:211)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at com.agomezmoron.saveImageGallery.SaveImageGallery.saveBase64Image(SaveImageGallery.java:127)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at com.agomezmoron.saveImageGallery.SaveImageGallery.execute(SaveImageGallery.java:49)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at org.apache.cordova.CordovaPlugin.execute(CordovaPlugin.java:98)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at org.apache.cordova.PluginManager.exec(PluginManager.java:132)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at org.apache.cordova.CordovaBridge.jsExec(CordovaBridge.java:59)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at org.apache.cordova.engine.SystemExposedJsApi.exec(SystemExposedJsApi.java:41)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at android.os.MessageQueue.nativePollOnce(Native Method)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at android.os.MessageQueue.next(MessageQueue.java:335)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at android.os.Looper.loop(Looper.java:193)
03-02 22:41:45.729 23172 23721 E PluginManager: 	at android.os.HandlerThread.run(HandlerThread.java:67)
03-02 22:41:45.729 23172 23721 W CordovaPlugin: Attempted to send a second callback for ID: SaveImageGallery380780538
03-02 22:41:45.729 23172 23721 W CordovaPlugin: Result was: "file"
```

So I've created a small workaround.